### PR TITLE
remove tension and diameter default_aes

### DIFF
--- a/R/GeomSpring.R
+++ b/R/GeomSpring.R
@@ -74,8 +74,6 @@ GeomSpring <- ggproto("GeomSpring", Geom,
       colour = "black",
       linewidth = 0.5,
       linetype = 1L,
-      alpha = NA,
-      diameter = 1,
-      tension = 0.75
+      alpha = NA
     )
 )


### PR DESCRIPTION
I think the tension and diameter need to be removed as default_aes for the `data$tension %||% ` approach suggested in the extenders discussions to work - e.g. tension to be proportional to length.